### PR TITLE
Change GoodarziQuadcopterEnv dynamics; R_B2I to R_I2B

### DIFF
--- a/src/environments/multicopters/GoodarziQuadcopterEnv.jl
+++ b/src/environments/multicopters/GoodarziQuadcopterEnv.jl
@@ -7,7 +7,7 @@ in 2014 American Control Conference, Jun. 2014, pp. 4925–4930, doi: 10.1109/AC
 # Variables
 p ∈ R^3: inertial position
 v ∈ R^3: inertial velocity
-R ∈ so(3): body-to-inertial rotation matrix (R_B2I)
+R ∈ so(3): inertial-to-body rotation matrix (R_I2B)
 ω ∈ R^3: angular rate of body in inertial frame
 """
 Base.@kwdef struct GoodarziQuadcopterEnv <: QuadcopterEnv
@@ -40,8 +40,8 @@ function dynamics!(env::GoodarziQuadcopterEnv)
         @unpack p, v, R, ω = state
         Ω = skew(ω)
         dstate.p = v
-        dstate.v = -(1/m)*f*R*e3 + g*e3
-        dstate.R = R*Ω
+        dstate.v = -(1/m)*f*R'*e3 + g*e3
+        dstate.R = -Ω*R
         dstate.ω = J_inv * (-Ω*J*ω + M)
         nothing
     end


### PR DESCRIPTION
There is no bug; just change the meaning of variables.
Now, `R` denotes R_I2B instead of R_B2I.