### PR TITLE
Add flux example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ in a `.jld2` file.
 from a `.jld2` file.
 
 ## Usage
+### Control and reinforcement learning with dynamical systems
 - For an example of **infinite-horizon continuous-time linear quadratic regulator (LQR)**, take a look at `test/lqr.jl`.
 - For an example of **continuous-time value-iteration adaptive dynamic programming (CT-VI-ADP)**, take a look at `main/continuous_time_vi_adp.jl`.
     - [T. Bian and Z.-P. Jiang, “Value Iteration, Adaptive Dynamic Programming, and Optimal Control of Nonlinear Systems,” in 2016 IEEE 55th Conference on Decision and Control (CDC), Las Vegas, NV, USA, Dec. 2016, pp. 3375–3380. doi: 10.1109/CDC.2016.7798777.](https://ieeexplore.ieee.org/document/7798777)
+### Scientific machine learning
+- For an example usage of [Flux.jl](https://github.com/FluxML/Flux.jl), see `main/flux_example.jl`.
 - [ ] To-do: add an example
 
 ## Issues

--- a/main/flux_example.jl
+++ b/main/flux_example.jl
@@ -1,0 +1,57 @@
+using FlightSims
+const FS = FlightSims
+using Flux
+using Flux.Data: DataLoader
+using Random
+using Transducers
+
+
+function f(K)
+    return function (x)
+        K*x
+    end
+end
+
+function sample_x(n)
+    2*rand(n) .- 1.0
+end
+
+function main(; seed=1)
+    Random.seed!(seed)
+    N = 1000  # no. of data
+    n = 2
+    m = 1
+    K = rand(m, n)
+    # data generation
+    xs = 1:N |> Map(i -> sample_x(n)) |> collect
+    fs = xs |> Map(f(K)) |> collect
+    partition_ratio = 0.8
+    data_train, data_test = FS.partitionTrainTest(zip(xs, fs) |> collect, partition_ratio)  # make a collection of datum and split it; NEVER split data for each labels, e.g., xs_train, xs_test = partitionTrainTest(xs)
+    xs_train = data_train |> Map(datum -> datum[1]) |> collect
+    fs_train = data_train |> Map(datum -> datum[2]) |> collect
+    xs_test = data_test |> Map(datum -> datum[1]) |> collect
+    fs_test = data_test |> Map(datum -> datum[2]) |> collect
+    # training
+    f̂ = Chain(Dense(n, m))  # approximator
+    dataloader = DataLoader((hcat(xs_train...), hcat(fs_train...)),  # `hcat` for Flux.jl
+                            batchsize=16, shuffle=true)
+    loss(x, f) = Flux.Losses.mse(f̂(x), f)
+    epochs = 30
+    opt = ADAM(1e-3)  # optimiser
+    for epoch in 0:epochs
+        println("epoch: $(epoch) / $(epochs)")
+        if epoch != 0
+            # for manual update
+            ps = params(f̂)
+            for (x, f) in dataloader
+                gs = gradient(ps) do
+                    loss(x, f)
+                end
+                Flux.update!(opt, ps, gs)
+            end
+            # # for automatic update
+            # Flux.Optimise.train!(loss, params(f̂), dataloader, opt)
+        end
+        @show loss(hcat(xs_test...), hcat(fs_test...))  # `hcat` for Flux.jl
+    end
+end

--- a/src/utils/partitionTrainTest.jl
+++ b/src/utils/partitionTrainTest.jl
@@ -1,0 +1,16 @@
+# split data into train and test
+"""
+    partitionTrainTest(data, at)
+Split a dataset into train and test datasets (array).
+"""
+function partitionTrainTest(data, at=0.8)
+    if size(data) |> length != 1
+        error("Invalid data type")
+    end
+    n = length(data)
+    idx = Random.shuffle(1:n)
+    train_idx = view(idx, 1:floor(Int, at*n))
+    test_idx = view(idx, (floor(Int, at*n)+1):n)
+    data[train_idx], data[test_idx]
+end
+

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,2 +1,3 @@
 include("approximators/approximators.jl")
 include("rotations.jl")
+include("partitionTrainTest.jl")


### PR DESCRIPTION
# Summary
Add a usage example of [Flux.jl](https://github.com/FluxML/Flux.jl).

# Notes
## utils
- A method `partitionTrainTest` splits data into two sets: training and test data sets.
## A note on Flux.jl and Transducers.jl
Note that the data is mainly dealt with by [Transducers.jl](https://github.com/JuliaFolds/Transducers.jl),
but Flux.jl recommends you to make the data as "horizontally concatenated" arrays.

### To @hnlee77
- `main/flux_example.jl` 에 Flux.jl 사용 예시 넣었어~ 봐보시면 좋을듯 ㅎㅎ
- 설명: Flux.jl 에서는 기본적으로 `horizontal concotenation` 을 권장하는데 (매트릭스 연산때문에), 보통 데이터를 들고다닐때는 Transducers.jl 를 이용하다보면 "array in array" 형태가 편해. 그래서 학습할때만 데이터 형태를 바꿔주는게 편해. 예시 파일 참고~