### PR TITLE
Add command generator; Power Loop

### DIFF
--- a/src/utils/CommandGenerator.jl
+++ b/src/utils/CommandGenerator.jl
@@ -73,7 +73,7 @@ function command_generator(cg::PowerLoop)
             # go straight
             _t0 = t0 + t_go_straight + t_loop
             _p0 = p0 + Δp
-            p_cmd = _p0 + (v0_norm*(t-_t0) + 0.5*a*(t-_t0)^2) * Δp_unit
+            p_cmd = _p0 + ((v0_norm+ΔV)*(t-_t0) - 0.5*a*(t-_t0)^2) * Δp_unit
         else
             # stop
             _p0 = p0 + 2*Δp

--- a/src/utils/CommandGenerator.jl
+++ b/src/utils/CommandGenerator.jl
@@ -1,0 +1,84 @@
+abstract type AbstractCommandGenerator end
+abstract type AbstractMulticopterCommandGenerator <: AbstractCommandGenerator end
+
+function command_generator(cg::AbstractCommandGenerator)
+    error("Not implemented")
+end
+
+"""
+# Refs.
+[1] E. Kaufmann, A. Loquercio, R. Ranftl, M. Müller, V. Koltun, and D. Scaramuzza, “Deep Drone Acrobatics,” arXiv:2006.05768 [cs], Jun. 2020, Accessed: Jun. 02, 2021. [Online]. Available: http://arxiv.org/abs/2006.05768
+# Variables
+d ∈ R^3: displacement
+ΔV ∈ R: speed increment
+r ∈ R^+: radius
+# Notes
+units: [m], [s]
+"""
+struct PowerLoop <: AbstractMulticopterCommandGenerator
+    p0::Vector
+    v0::Vector
+    Δp::Vector
+    ΔV::Real
+    r::Real
+    t0::Real
+    t_go_straight::Real
+    t_loop::Real 
+end
+
+function PowerLoop(;
+        p0=zeros(3), v0=[1, 0, 0], d=4, ΔV=4.5, r=1.5,
+        t0=0.0, t_go_straight=3.0, t_loop=2*π*r/(norm(v0)+ΔV))
+    @assert r > 0
+    @assert t_go_straight > 0
+    @assert t_loop > 0
+    Δp = d * (v0/norm(v0))
+    PowerLoop(p0, v0, Δp, ΔV, r, t0, t_go_straight, t_loop)
+end
+
+"""
+# Notes
+NED coordinate system.
+- go straight
+norm(v0)*(t-t0) + 0.5*a*(t-t0)^2 = norm(Δp)
+- loop
+r*θ = V*(t-t0-t_go_straight)
+"""
+function command_generator(cg::PowerLoop)
+    @unpack t0, p0, v0, Δp, t_go_straight, t_loop, r, ΔV = cg
+    v0_norm = norm(v0)
+    Δp_norm = norm(Δp)
+    a = (Δp_norm - v0_norm*t_go_straight) / (0.5*t_go_straight^2)
+    Δp_unit = Δp / Δp_norm
+    to_the_centre = cross(cross([0, 0, 1], v0), v0)
+    to_the_centre_unit = to_the_centre / norm(to_the_centre)  # unit vec
+    v0_unit = v0 / v0_norm
+    return function (t)
+        p_cmd = nothing
+        if t < t0
+            # before start
+            p_cmd = p0
+        elseif t < t0 + t_go_straight
+            # go straight
+            _t0 = t0
+            _p0 = p0
+            p_cmd = _p0 + (v0_norm*(t-_t0) + 0.5*a*(t-_t0)^2) * Δp_unit
+        elseif t < t0 + t_go_straight + t_loop
+            # loop
+            _t0 = t0 + t_go_straight
+            _p0 = p0 + Δp + r*to_the_centre_unit
+            θ = (v0_norm+ΔV)*(t-_t0) / r
+            p_cmd = _p0 - r*to_the_centre_unit*cos(θ) + v0_unit*sin(θ)
+        elseif t < t0 + t_go_straight + t_loop + t_go_straight
+            # go straight
+            _t0 = t0 + t_go_straight + t_loop
+            _p0 = p0 + Δp
+            p_cmd = _p0 + (v0_norm*(t-_t0) + 0.5*a*(t-_t0)^2) * Δp_unit
+        else
+            # stop
+            _p0 = p0 + 2*Δp
+            p_cmd = _p0
+        end
+        return p_cmd
+    end
+end

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,3 +1,4 @@
 include("approximators/approximators.jl")
 include("rotations.jl")
 include("partitionTrainTest.jl")
+include("CommandGenerator.jl")

--- a/test/utils/command_generator.jl
+++ b/test/utils/command_generator.jl
@@ -21,7 +21,7 @@ function test()
                     label="trajectory",
                     title="Power Loop")
     anim = Animation()
-    for p in ps[1:1:end]
+    for p in ps[1:10:end]
         push!(p_traj, p...)
         frame(anim)
     end

--- a/test/utils/command_generator.jl
+++ b/test/utils/command_generator.jl
@@ -10,19 +10,19 @@ function test()
     cg = FS.command_generator(power_loop)
     @unpack t0, t_go_straight, t_loop = power_loop
     Δt = 0.01
-    tf = t0 + 2*t_go_straight + t_loop + 10
+    tf = t0 + 2*t_go_straight + t_loop + 5
     ts = t0:Δt:tf
     ps = ts |> Map(cg) |> collect
     ps_cat = hcat(ps...)'
     p_traj = plot3d(1;
-                    xlim=(-30, 30),
-                    ylim=(-30, 30),
-                    zlim=(-30, 30),
+                    xlim=(-20, 20),
+                    ylim=(-20, 20),
+                    zlim=(-20, 20),
                     aspect_ratio=:equal,
                     label="trajectory",
                     title="Power Loop")
     anim = Animation()
-    for p in ps[1:20:end]
+    for p in ps[1:10:end]
         push!(p_traj, p...)
         frame(anim)
     end

--- a/test/utils/command_generator.jl
+++ b/test/utils/command_generator.jl
@@ -10,18 +10,19 @@ function test()
     cg = FS.command_generator(power_loop)
     @unpack t0, t_go_straight, t_loop = power_loop
     Δt = 0.01
-    tf = t0 + 2*t_go_straight + t_loop + 3
+    tf = t0 + 2*t_go_straight + t_loop + 10
     ts = t0:Δt:tf
     ps = ts |> Map(cg) |> collect
     ps_cat = hcat(ps...)'
     p_traj = plot3d(1;
-                    xlim=(-1, 10),
-                    ylim=(-1, 1),
-                    zlim=(-10, 10),
+                    xlim=(-30, 30),
+                    ylim=(-30, 30),
+                    zlim=(-30, 30),
+                    aspect_ratio=:equal,
                     label="trajectory",
                     title="Power Loop")
     anim = Animation()
-    for p in ps[1:10:end]
+    for p in ps[1:20:end]
         push!(p_traj, p...)
         frame(anim)
     end

--- a/test/utils/command_generator.jl
+++ b/test/utils/command_generator.jl
@@ -1,0 +1,29 @@
+using FlightSims
+const FS = FlightSims
+using UnPack
+using Transducers
+using Plots
+
+
+function test()
+    power_loop = FS.PowerLoop()
+    cg = FS.command_generator(power_loop)
+    @unpack t0, t_go_straight, t_loop = power_loop
+    Δt = 0.01
+    tf = t0 + 2*t_go_straight + t_loop + 3
+    ts = t0:Δt:tf
+    ps = ts |> Map(cg) |> collect
+    ps_cat = hcat(ps...)'
+    p_traj = plot3d(1;
+                    xlim=(-1, 10),
+                    ylim=(-1, 1),
+                    zlim=(-10, 10),
+                    label="trajectory",
+                    title="Power Loop")
+    anim = Animation()
+    for p in ps[1:1:end]
+        push!(p_traj, p...)
+        frame(anim)
+    end
+    gif(anim, "power_loop.gif")
+end


### PR DESCRIPTION


An aerobatic manoeuvre, Power Loop, is implemented; see [E. Kaufmann, A. Loquercio, R. Ranftl, M. Müller, V. Koltun, and D. Scaramuzza, “Deep Drone Acrobatics,” arXiv:2006.05768 [cs], Jun. 2020, Accessed: Jun. 02, 2021. [Online]. Available: http://arxiv.org/abs/2006.05768
](https://arxiv.org/pdf/2006.05768.pdf).

# Phases
1. `start` (with initial speed)
2. `go-straight` (with constant acceleration)
3. `loop` (circle)
4. `go-straight` (again, with negative constant acceleration)
5. `finish` (go-straight with constant speed)


![power_loop](https://user-images.githubusercontent.com/43136096/120450056-04214a00-c3cb-11eb-95e1-d6f005c0e4fa.gif)

