### PR TITLE
Add mixers for quadcopters

### DIFF
--- a/main/backstepping_tracking.jl
+++ b/main/backstepping_tracking.jl
@@ -1,11 +1,12 @@
 using FlightSims
 const FS = FlightSims
+using UnPack, ComponentArrays
 using Transducers
 using Plots
 
 
 function make_env()
-    multicopter = GoodarziQuadcopterEnv()
+    multicopter = IslamQuadcopterEnv()
     @unpack m, g = multicopter
     x0_multicopter = State(multicopter)()
     pos0 = copy(x0_multicopter.p)

--- a/src/FlightSims.jl
+++ b/src/FlightSims.jl
@@ -19,7 +19,7 @@ export AbstractEnv, State, dynamics, dynamics!, apply_inputs
 export sim, process, load
 # envs
 export TwoDimensionalNonlinearPolynomialEnv, LinearSystemEnv, ReferenceModelEnv
-export GoodarziQuadcopterEnv
+export IslamQuadcopterEnv, GoodarziQuadcopterEnv
 export BacksteppingPositionControllerEnv
 # algorithms
 export command

--- a/src/environments/integrated_environments/integrated_environments.jl
+++ b/src/environments/integrated_environments/integrated_environments.jl
@@ -1,3 +1,41 @@
+"""
+IslamQuadcopterEnv + BacksteppingPositionControllerEnv
+"""
+function IslamQuadcopter_BacksteppingControllerEnv(; kwargs_multicopter=Dict(), kwargs_controller=Dict(:x_cmd_func => nothing))
+    multicopter = IslamQuadcopterEnv(; kwargs_multicopter...)
+    @unpack m = multicopter
+    controller = BacksteppingPositionControllerEnv(m; kwargs_controller...)
+    multicopter, controller
+end
+
+function State(multicopter::IslamQuadcopterEnv, controller::BacksteppingPositionControllerEnv)
+    @unpack m, g = multicopter
+    return function (args_multicopter=())
+        x_multicopter = State(multicopter)(args_multicopter...)
+        pos0 = copy(x_multicopter.p)
+        x_controller = State(controller)(pos0, m, g)
+        ComponentArray(multicopter=x_multicopter, controller=x_controller)
+    end
+end
+
+function dynamics!(multicopter::IslamQuadcopterEnv, controller::BacksteppingPositionControllerEnv;
+    mixer=Mixer(multicopter.B))
+    @unpack m, J, g = multicopter
+    return function (dx, x, p, t; pos_cmd=nothing)
+        @unpack p, v, R, ω = x.multicopter
+        @unpack ref_model, Td = x.controller
+        xd, vd, ad, ȧd, äd = ref_model.x_0, ref_model.x_1, ref_model.x_2, ref_model.x_3, ref_model.x_4
+        νd, Ṫd = command(controller)(p, v, R, ω, xd, vd, ad, ȧd, äd, Td, m, J, g)
+        u_cmd = mixer(νd)
+        dynamics!(multicopter)(dx.multicopter, x.multicopter, (), t; u=u_cmd)
+        dynamics!(controller)(dx.controller, x.controller, (), t; pos_cmd=pos_cmd, Ṫd=Ṫd)
+        nothing
+    end
+end
+
+"""
+GoodarziQuadcopterEnv + BacksteppingPositionControllerEnv
+"""
 function GoodarziQuadcopter_BacksteppingControllerEnv(; kwargs_multicopter=Dict(), kwargs_controller=Dict(:x_cmd_func => nothing))
     multicopter = GoodarziQuadcopterEnv(; kwargs_multicopter...)
     @unpack m = multicopter

--- a/src/environments/multicopters/GoodarziQuadcopterEnv.jl
+++ b/src/environments/multicopters/GoodarziQuadcopterEnv.jl
@@ -17,30 +17,27 @@ Base.@kwdef struct GoodarziQuadcopterEnv <: QuadcopterEnv
     g = 9.81  # m/s²
 end
 
-function State(env::GoodarziQuadcopterEnv)
-    return function (p=zeros(3), v=zeros(3), R=one(RotMatrix{3}), ω=zeros(3))
-        ComponentArray(p=p, v=v, R=R, ω=ω)
-    end
-end
-
 """
 # Variables
 f ∈ R: thrust magnitude
 M ∈ R^3: moment
 """
 function dynamics!(env::GoodarziQuadcopterEnv)
-    @unpack m, g, J, J_inv = env
-    e3 = [0, 0, 1]
-    skew(x) = [    0 -x[3]  x[2];
-                x[3]     0 -x[1];
-               -x[2]  x[1]    0]
-    return function (dstate, state, p, t; f=f, M=M)
-        @unpack p, v, R, ω = state
-        Ω = skew(ω)
-        dstate.p = v
-        dstate.v = -(1/m)*f*R'*e3 + g*e3
-        dstate.R = -Ω*R
-        dstate.ω = J_inv * (-Ω*J*ω + M)
-        nothing
+    return function (dX, X, p, t; f, M)
+        _dynamics!(env)(dX, X, p, t; f=f, M=M)
     end
+    # @unpack m, g, J, J_inv = env
+    # e3 = [0, 0, 1]
+    # skew(x) = [    0 -x[3]  x[2];
+    #             x[3]     0 -x[1];
+    #            -x[2]  x[1]    0]
+    # return function (dstate, state, p, t; f=f, M=M)
+    #     @unpack p, v, R, ω = state
+    #     Ω = skew(ω)
+    #     dstate.p = v
+    #     dstate.v = -(1/m)*f*R'*e3 + g*e3
+    #     dstate.R = -Ω*R
+    #     dstate.ω = J_inv * (-Ω*J*ω + M)
+    #     nothing
+    # end
 end

--- a/src/environments/multicopters/IslamQuadcopterEnv.jl
+++ b/src/environments/multicopters/IslamQuadcopterEnv.jl
@@ -1,0 +1,43 @@
+"""
+# References
+[1] M. Islam, M. Okasha, and M. M. Idres, “Dynamics and control of quadcopter using linear model predictive control approach,” IOP Conf. Ser.: Mater. Sci. Eng., vol. 270, p. 012007, Dec. 2017, doi: 10.1088/1757-899X/270/1/012007.
+"""
+Base.@kwdef struct IslamQuadcopterEnv <: QuadcopterEnv
+    J = Diagonal([7.5e-3, 7.5e-3, 1.3e-2])  # kg m^2
+    l = 0.23  # m
+    kf = 3.13e-5  # N s^2
+    kM = 7.5e-7  # N m s^2
+    m = 0.65  # kg
+    g = 9.81  # m / s^2
+    B = [kf  kf  kf  kf;
+          0 -kf   0  kf;
+         kf   0 -kf   0;
+         kM -kM  kM -kM]
+    # drags
+    # kt = Diagonal(0.1*ones(3))  # Ns / m
+    # kr = Diagonal(0.1*ones(3))  # N m s
+    # input limits
+    u_min = zeros(4)
+    u_max = (m*g/kf) * ones(4)
+end
+
+function saturate_func(env::IslamQuadcopterEnv)
+    @unpack u_min, u_max = env
+    return function (u)
+        u_saturated = clamp.(u, u_min, u_max)
+    end
+end
+
+"""
+u .>= 0: square of rotor angular rate
+"""
+function dynamics!(env::IslamQuadcopterEnv)
+    @unpack B = env
+    saturate = saturate_func(env)
+    return function (dX, X, p, t; u)
+        _u = saturate(u)
+        ν = B * _u
+        f, M = ν[1], ν[2:4]
+        _dynamics!(env)(dX, X, p, t; f=f, M=M)
+    end
+end

--- a/src/environments/multicopters/mixers.jl
+++ b/src/environments/multicopters/mixers.jl
@@ -1,0 +1,21 @@
+abstract type AbstractMixer end
+
+"""
+Moore-Penrose inverse (pseudo inverse) mixer.
+"""
+struct Mixer <: AbstractMixer
+    B_inv
+    function Mixer(B)
+        B_inv = pinv(B)
+        new(B_inv)
+    end
+end
+"""
+# Variables
+f ∈ R: total thurst
+M ∈ R^3: moment
+ν: [f, M...]
+# Notes
+ν = B*u
+"""
+(mx::Mixer)(ν) = mx.B_inv * ν

--- a/src/environments/multicopters/multicopters.jl
+++ b/src/environments/multicopters/multicopters.jl
@@ -1,2 +1,6 @@
+# multicopter
 abstract type MulticopterEnv <: AbstractEnv end
+# mixer
+include("mixers.jl")
+# quadcopter
 include("quadcopters.jl")

--- a/src/environments/multicopters/quadcopters.jl
+++ b/src/environments/multicopters/quadcopters.jl
@@ -1,2 +1,41 @@
 abstract type QuadcopterEnv <: MulticopterEnv end
+
+"""
+Common state structure of QuadcopterEnv
+"""
+function State(env::QuadcopterEnv)
+    return function (p=zeros(3), v=zeros(3), R=one(RotMatrix{3}), ω=zeros(3))
+        ComponentArray(p=p, v=v, R=R, ω=ω)
+    end
+end
+
+"""
+Input saturation
+"""
+function saturate_func(env::QuadcopterEnv)
+    error("Not implemented")
+end
+
+"""
+Common dynamics of QuadcopterEnv
+"""
+function _dynamics!(env::QuadcopterEnv)
+    @unpack m, g, J = env
+    J_inv = inv(J)
+    e3 = [0, 0, 1]
+    skew(x) = [    0 -x[3]  x[2];
+                x[3]     0 -x[1];
+               -x[2]  x[1]    0]
+    return function (dX, X, p, t; f, M)
+        @unpack p, v, R, ω = X
+        Ω = skew(ω)
+        dX.p = v
+        dX.v = -(1/m)*f*R'*e3 + g*e3
+        dX.R = -Ω*R
+        dX.ω = J_inv * (-Ω*J*ω + M)
+        nothing
+    end
+end
+
 include("GoodarziQuadcopterEnv.jl")
+include("IslamQuadcopterEnv.jl")


### PR DESCRIPTION
Resolves #38.

- Instead of modifying an existing quadcopter model `GoodarziQuadcopterEnv`, I added a mixer structure `Mixer` and `a new quadcopter model `IslamQuadcopterEnv`.
    - [M. Islam, M. Okasha, and M. M. Idres, “Dynamics and control of quadcopter using linear model predictive control approach,” IOP Conf. Ser.: Mater. Sci. Eng., vol. 270, p. 012007, Dec. 2017, doi: 10.1088/1757-899X/270/1/012007.
](https://iopscience.iop.org/article/10.1088/1757-899X/270/1/012007/pdf)
- The interface of using `env::QuadcopterEnv` becomes easier than before!
- Some bugs in #37 are fixed (e.g., dependencies).