### PR TITLE
Fix a bug of LinearSystemEnv

### DIFF
--- a/src/environments/basics/LinearSystemEnv.jl
+++ b/src/environments/basics/LinearSystemEnv.jl
@@ -16,8 +16,7 @@ end
 function dynamics!(env::LinearSystemEnv)
     @unpack A, B = env
     return function (dx, x, p, t; u)
-        @assert length(u) == 1
-        _u = u[1]
+        _u = length(u) == 1 ? u[1] : u
         dx .= A*x + B*_u
         nothing
     end


### PR DESCRIPTION
It worked only for `length(u) == 1`, i.e., scalar control input.
See the code change.