### PR TITLE
Add saving API

### DIFF
--- a/src/APIs/simulation.jl
+++ b/src/APIs/simulation.jl
@@ -1,11 +1,39 @@
 ## Simulation
+"""
+# Notes
+- `saving_func` should be a function
+    - whose input is `(x, t, integrator::DiffEqBase.DEIntegrator)`
+    - and whose output is `nt::NamedTuple`.
+- Default settings for saving
+    - save values "after all other callbacks"
+    - `saveat=[]` will save data at every time step.
+"""
 function sim(state0, dyn, p=nothing;
-        t0=0.0, tf=1.0, solver=Tsit5(), callback::DiffEqBase.DECallback=CallbackSet(), kwargs...
+        t0=0.0, tf=1.0, solver=Tsit5(),
+        callback::DiffEqBase.DECallback=CallbackSet(),
+        saving_func=nothing, saveat=[],
+        kwargs...,
     )
     tspan = (t0, tf)
     prob = ODEProblem(dyn, state0, tspan, p)
+    saved_values = nothing
+    if saving_func != nothing
+        saved_values = SavedValues(Float64, NamedTuple)
+        cb_save = SavingCallback(saving_func, saved_values; saveat=saveat, tdir=Int(sign(tspan[2]-tspan[1])))
+        callback = CallbackSet(callback, cb_save)  # save values "after all other callbacks"
+    end
     sol = solve(prob, solver; callback=callback, kwargs...)
-    prob, sol
+    if saving_func == nothing
+        return prob, sol
+    else
+        df = DataFrame(times=saved_values.t)
+        all_keys = (saved_values.saveval |> Map(keys) |> union)[1]
+        for key in all_keys
+            _getproperty(x) = isdefined(x, key) ? getproperty(x, key) : missing
+            df[!, key] = saved_values.saveval |> Map(_getproperty) |> collect
+        end
+        return prob, sol, df
+    end
 end
 
 

--- a/test/APIs/simulation.jl
+++ b/test/APIs/simulation.jl
@@ -1,0 +1,27 @@
+using FlightSims
+using LinearAlgebra
+using ControlSystems: lqr
+using DifferentialEquations
+using DataFrames
+using Transducers
+
+
+function test()
+    n = 3
+    dynamics!(dx, x, p, t) = dx .= -p*x
+    x0 = ones(n)
+    p0 = 1.0
+    tf = -1.00
+    Δt = -0.01
+    Δt2 = -0.004
+    affect!(integrator) = integrator.p = 0.99*integrator.p
+    affect2!(integrator) = integrator.p = 0.99*integrator.p
+    cb_update = PeriodicCallback(affect!, Δt; initial_affect=false)
+    cb_update2 = PeriodicCallback(affect2!, Δt2; initial_affect=false)
+    saving_func(x, t, integrator) = t > 0.5 ? (; p=integrator.p) : (; x=x, p=integrator.p)  # varying keys
+    cb = CallbackSet(cb_update, cb_update2)
+    prob, sol, df = sim(x0, dynamics!, p0;
+                        tf=tf, callback=cb,
+                        saving_func=saving_func)
+    df
+end


### PR DESCRIPTION
Resolve #49.

You can save intermediate data by adding a function `saving_func` as `sim(..., saving_func=saving_func)`.
Without specific `saveat` option, it will save all results.
The saving function `saving_func` should be a function
- whose input is **`(x, t, integrator)`**
- and whose output is **`nt::NamedTuple`**.

For the saving stochastic input, it is recommended you to "update" the parameter `p` of your dynamics (probably via [DiscreteCallback](https://diffeq.sciml.ai/stable/features/callback_functions/#DiffEqBase.DiscreteCallback)) and save it.

An example code is provided in `test/APIs/simulation.jl`.


- code
```julia
using FlightSims
using LinearAlgebra
using ControlSystems: lqr
using DifferentialEquations
using DataFrames
using Transducers


function test()
    n = 3
    dynamics!(dx, x, p, t) = dx .= -p*x
    x0 = ones(n)
    p0 = 1.0
    tf = -1.00
    Δt = -0.01
    Δt2 = -0.004
    affect!(integrator) = integrator.p = 0.99*integrator.p
    affect2!(integrator) = integrator.p = 0.99*integrator.p
    cb_update = PeriodicCallback(affect!, Δt; initial_affect=false)
    cb_update2 = PeriodicCallback(affect2!, Δt2; initial_affect=false)
    saving_func(x, t, integrator) = t > 0.5 ? (; p=integrator.p) : (; x=x, p=integrator.p)  # varying keys
    cb = CallbackSet(cb_update, cb_update2)
    prob, sol, df = sim(x0, dynamics!, p0;
                        tf=tf, callback=cb,
                        saving_func=saving_func)
    df
end
```
- result
```julia
julia> test()
301×3 DataFrame
 Row │ times    x                            p
     │ Float64  Array…                       Float64
─────┼─────────────────────────────────────────────────
   1 │   0.0    [1.32131, 1.32131, 1.32131]  1.0
   2 │  -0.004  [1.32131, 1.32131, 1.32131]  0.99
   3 │  -0.008  [1.32131, 1.32131, 1.32131]  0.9801
   4 │  -0.01   [1.32131, 1.32131, 1.32131]  0.970299
   5 │  -0.012  [1.32131, 1.32131, 1.32131]  0.960596
   6 │  -0.016  [1.32131, 1.32131, 1.32131]  0.95099
   7 │  -0.02   [1.32131, 1.32131, 1.32131]  0.932065
   8 │  -0.024  [1.32131, 1.32131, 1.32131]  0.922745
   9 │  -0.028  [1.32131, 1.32131, 1.32131]  0.913517
  10 │  -0.03   [1.32131, 1.32131, 1.32131]  0.904382
  11 │  -0.032  [1.32131, 1.32131, 1.32131]  0.895338
  12 │  -0.036  [1.32131, 1.32131, 1.32131]  0.886385
  13 │  -0.04   [1.32131, 1.32131, 1.32131]  0.868746
  14 │  -0.044  [1.32131, 1.32131, 1.32131]  0.860058
  15 │  -0.048  [1.32131, 1.32131, 1.32131]  0.851458
  16 │  -0.05   [1.32131, 1.32131, 1.32131]  0.842943
  17 │  -0.052  [1.32131, 1.32131, 1.32131]  0.834514
  18 │  -0.056  [1.32131, 1.32131, 1.32131]  0.826169
  19 │  -0.06   [1.32131, 1.32131, 1.32131]  0.809728
  20 │  -0.064  [1.32131, 1.32131, 1.32131]  0.801631
  21 │  -0.068  [1.32131, 1.32131, 1.32131]  0.793614
  22 │  -0.07   [1.32131, 1.32131, 1.32131]  0.785678
  23 │  -0.072  [1.32131, 1.32131, 1.32131]  0.777821
  ⋮  │    ⋮                  ⋮                   ⋮
 279 │  -0.928  [1.32131, 1.32131, 1.32131]  0.0385304
 280 │  -0.93   [1.32131, 1.32131, 1.32131]  0.0381451
 281 │  -0.932  [1.32131, 1.32131, 1.32131]  0.0377636
 282 │  -0.936  [1.32131, 1.32131, 1.32131]  0.037386
 283 │  -0.94   [1.32131, 1.32131, 1.32131]  0.036642
 284 │  -0.944  [1.32131, 1.32131, 1.32131]  0.0362756
 285 │  -0.948  [1.32131, 1.32131, 1.32131]  0.0359128
 286 │  -0.95   [1.32131, 1.32131, 1.32131]  0.0355537
 287 │  -0.952  [1.32131, 1.32131, 1.32131]  0.0351981
 288 │  -0.956  [1.32131, 1.32131, 1.32131]  0.0348462
 289 │  -0.96   [1.32131, 1.32131, 1.32131]  0.0341527
 290 │  -0.964  [1.32131, 1.32131, 1.32131]  0.0338112
 291 │  -0.968  [1.32131, 1.32131, 1.32131]  0.0334731
 292 │  -0.97   [1.32131, 1.32131, 1.32131]  0.0331384
 293 │  -0.972  [1.32131, 1.32131, 1.32131]  0.032807
 294 │  -0.976  [1.32131, 1.32131, 1.32131]  0.0324789
 295 │  -0.98   [1.32131, 1.32131, 1.32131]  0.0318326
 296 │  -0.984  [1.32131, 1.32131, 1.32131]  0.0315142
 297 │  -0.988  [1.32131, 1.32131, 1.32131]  0.0311991
 298 │  -0.99   [1.32131, 1.32131, 1.32131]  0.0308871
 299 │  -0.992  [1.32131, 1.32131, 1.32131]  0.0305782
 300 │  -0.996  [1.32131, 1.32131, 1.32131]  0.0302725
 301 │  -1.0    [1.32131, 1.32131, 1.32131]  0.0302725
                                       255 rows omitted

```