### PR TITLE
Restrict PID args

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,8 @@ using Transducers
 function test()
     # linear system
     A = [0 1;
-         0 0]
-    B = [0;
-         1]
+         0 0]  # 2 x 2
+    B = [0 1]'  # 2 x 1
     n, m = 2, 1
     env = LinearSystemEnv(A, B)  # exported from FlightSims
     x0 = State(env)([1.0, 2.0])

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -29,7 +29,7 @@ Note: ê is estimated via LPF
 function Dynamics!(controller::PID)
     @unpack τ = controller
     @Loggable function dynamics!(dx, x, p, t; e)
-        @assert typeof(e) != Number
+        @assert !(typeof(e) <: Number)  # make sure that `e` is a 1-d array
         @unpack ∫e, ê = x
         @onlylog e, ∫e, ê
         dx.∫e .= e

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -29,6 +29,7 @@ Note: ê is estimated via LPF
 function Dynamics!(controller::PID)
     @unpack τ = controller
     @Loggable function dynamics!(dx, x, p, t; e)
+        @assert typeof(e) != Number
         @unpack ∫e, ê = x
         @onlylog e, ∫e, ê
         dx.∫e .= e

--- a/test/lqr.jl
+++ b/test/lqr.jl
@@ -10,9 +10,8 @@ using Transducers
 function test()
     # linear system
     A = [0 1;
-         0 0]
-    B = [0;
-         1]
+         0 0]  # 2 x 2
+    B = [0 1]'  # 2 x 1
     n, m = 2, 1
     env = LinearSystemEnv(A, B)  # exported from FlightSims
     x0 = State(env)([1.0, 2.0])


### PR DESCRIPTION
PID's argument should be an array whose length is one.
Note: `README.md`'s LQR example is updated.