### PR TITLE
Organise exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,15 @@ function test()
     Δt = 0.01
     affect!(integrator) = integrator.p = copy(integrator.u)  # auxiliary callback funciton
     cb = PeriodicCallback(affect!, Δt; initial_affect=true)  # auxiliary callback
-    @Loggable function dynamics!(dx, x, p, t; u)
+    @Loggable function dynamics!(dx, x, p, t)
         @onlylog p  # activate this line only when logging data
+        u = u_lqr(x)
         @log x, u
         @nested_log Dynamics!(env)(dx, x, p, t; u=u)  # exported `state` and `input` from `Dynamics!(env)`
     end
     prob, df = sim(
                    x0,  # initial condition
-                   apply_inputs(dynamics!; u=u_lqr),  # dynamics with input of LQR
+                   dynamics!,  # dynamics with input of LQR
                    p0;
                    tf=tf,  # final time
                    callback=cb,

--- a/src/FlightSims.jl
+++ b/src/FlightSims.jl
@@ -17,8 +17,8 @@ using Flux
 using Flux.Data: DataLoader
 
 ### APIs
-export AbstractEnv, State, Params, Dynamics, Dynamics!, apply_inputs, DatumFormat, save_inputs
-export sim, Process, load
+export AbstractEnv, State, Params, Dynamics, Dynamics!
+export sim, apply_inputs, Command
 @reexport using SimulationLogger
 ### envs
 ## basics
@@ -38,7 +38,7 @@ export CTValueIterationADP, BehaviouralCloning, CTLinearIRL
 # utils
 export AbstractApproximator, LinearApproximator
 export PolynomialBasis, euler
-export PowerLoop, Command, HelixCommandGenerator
+export PowerLoop, HelixCommandGenerator
 
 
 include("APIs/APIs.jl")

--- a/src/environments/allocators/PseudoInverseAllocator.jl
+++ b/src/environments/allocators/PseudoInverseAllocator.jl
@@ -15,6 +15,6 @@ end
 # Notes
 ν = B*u where u: control input
 """
-function (allocator::PseudoInverseAllocator)(ν, Λ=Diagonal(ones(size(ν))))
+function (allocator::PseudoInverseAllocator)(ν, Λ=Diagonal(ones(size(allocator.B_pinv)[1])))
     (pinv(Λ) * allocator.B_pinv) * ν  # pinv(B*Λ) = pinv(Λ) * pinv(B)
 end

--- a/src/environments/basics/LinearSystemEnv.jl
+++ b/src/environments/basics/LinearSystemEnv.jl
@@ -21,13 +21,6 @@ function Dynamics!(env::LinearSystemEnv)
     @Loggable function dynamics!(dx, x, p, t; u)
         @log state = x
         @log input = u
-        # _u = length(u) == 1 ? u[1] : u
-        # @show B*_u
-        # @show A
-        # @show x
-        # @show A*x
-        # dx .= A*x + B*_u
         dx .= A*x + B*u
-        nothing
     end
 end

--- a/src/environments/controllers/LQR.jl
+++ b/src/environments/controllers/LQR.jl
@@ -34,9 +34,7 @@ Minimise J = ∫ (x' Q x + u' R u) from 0 to ∞
 """
 function OptimalController(lqr::LQR)
     K = optimal_gain(lqr)
-    return function (x, p, t)
-        -K*x
-    end
+    (x) -> -K*x
 end
 
 function solutions(lqr::LQR)

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -9,7 +9,7 @@ struct PID <: AbstractEnv
     K_D
     τ
     windup_limit
-    function PID(K_P, K_I, K_D; τ=1e-2, windup_limit=1e1)
+    function PID(K_P, K_I, K_D; τ=1e-1, windup_limit=1e0)
         @assert windup_limit > 0.0
         new(K_P, K_I, K_D, τ, windup_limit)
     end

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -34,7 +34,7 @@ function Dynamics!(controller::PID)
         @assert !(typeof(e) <: Number)  # make sure that `e` is a 1-d array
         @unpack ∫e, ê = x
         @onlylog e, ∫e, ê
-        if norm(e) < windup_limit
+        if norm(∫e) < windup_limit
             dx.∫e .= e
         else
             dx.∫e .= zero.(e)

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -9,7 +9,7 @@ struct PID <: AbstractEnv
     K_D
     τ
     windup_limit
-    function PID(K_P, K_I, K_D; τ=1e-2, windup_limit=1e0)
+    function PID(K_P, K_I, K_D; τ=1e-2, windup_limit=1e1)
         @assert windup_limit > 0.0
         new(K_P, K_I, K_D, τ, windup_limit)
     end

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -9,7 +9,7 @@ struct PID <: AbstractEnv
     K_D
     τ
     windup_limit
-    function PID(K_P, K_I, K_D; τ=1e-2, windup_limit=1e1)
+    function PID(K_P, K_I, K_D; τ=1e-2, windup_limit=1e0)
         @assert windup_limit > 0.0
         new(K_P, K_I, K_D, τ, windup_limit)
     end
@@ -34,7 +34,7 @@ function Dynamics!(controller::PID)
         @assert !(typeof(e) <: Number)  # make sure that `e` is a 1-d array
         @unpack ∫e, ê = x
         @onlylog e, ∫e, ê
-        if windup_limit > norm(e)
+        if norm(e) < windup_limit
             dx.∫e .= e
         else
             dx.∫e .= zero.(e)

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -8,8 +8,10 @@ struct PID <: AbstractEnv
     K_I
     K_D
     τ
-    function PID(K_P, K_I, K_D; τ=1e-2)
-        new(K_P, K_I, K_D, τ)
+    windup_limit
+    function PID(K_P, K_I, K_D; τ=1e-2, windup_limit=1e1)
+        @assert windup_limit > 0.0
+        new(K_P, K_I, K_D, τ, windup_limit)
     end
 end
 
@@ -27,12 +29,16 @@ end
 Note: ê is estimated via LPF
 """
 function Dynamics!(controller::PID)
-    @unpack τ = controller
+    @unpack τ, windup_limit = controller
     @Loggable function dynamics!(dx, x, p, t; e)
         @assert !(typeof(e) <: Number)  # make sure that `e` is a 1-d array
         @unpack ∫e, ê = x
         @onlylog e, ∫e, ê
-        dx.∫e .= e
+        if windup_limit > norm(e)
+            dx.∫e .= e
+        else
+            dx.∫e .= zero.(e)
+        end
         dx.ê .= deriv_ê(controller, e, ê)
     end
 end

--- a/src/utils/rotations.jl
+++ b/src/utils/rotations.jl
@@ -1,3 +1,15 @@
-function euler(x::Rotations.RotXYZ)
-    [x.theta1, x.theta2, x.theta3]
+"""
+# Variables
+- ϕ: roll
+- θ: pitch
+- ψ: yaw
+# Notes
+- RotXYZ (Z first applied)
+- `R` denotes the rotation matrix from I (inertial) to B (body).
+"""
+function euler(R::Rotations.RotXYZ)
+    ϕ = R.theta1  # X
+    θ = R.theta2  # Y
+    ψ = R.theta3  # Z
+    [ϕ, θ, ψ]
 end

--- a/test/lqr.jl
+++ b/test/lqr.jl
@@ -27,14 +27,15 @@ function test()
     Δt = 0.01
     affect!(integrator) = integrator.p = copy(integrator.u)  # auxiliary callback funciton
     cb = PeriodicCallback(affect!, Δt; initial_affect=true)  # auxiliary callback
-    @Loggable function dynamics!(dx, x, p, t; u)
+    @Loggable function dynamics!(dx, x, p, t)
         @onlylog p  # activate this line only when logging data
+        u = u_lqr(x)
         @log x, u
         @nested_log Dynamics!(env)(dx, x, p, t; u=u)  # exported `state` and `input` from `Dynamics!(env)`
     end
     prob, df = sim(
                    x0,  # initial condition
-                   apply_inputs(dynamics!; u=u_lqr),  # dynamics with input of LQR
+                   dynamics!,  # dynamics with input of LQR
                    p0;
                    tf=tf,  # final time
                    callback=cb,


### PR DESCRIPTION
1. `OptimalController(env::LQR)` now produces a function whose argument is `x` (state), not `(x, p, t)`.
2. `PID` now has a property `windup_limit > 0` for anti-windup control.
3. Some documentation is done.