### PR TITLE
Update PID; improved D term estimation 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlightSims"
 uuid = "a4c2f6ca-3fbe-4430-8ede-32935de4c069"
 authors = ["JinraeKim <kjl950403@gmail.com> and contributors"]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Take a look at `src/environments`.
     - **controllers**
         - (Linear quadratic regulator) `LQR`
         - (Proportional-Integral-Derivative controller) `PID`
-            - Note that the derivative term is obtained via low-pass-filter (LPF).
+            - Note that the derivative term is obtained via second-order filter.
     - **integrated_environments**
         - See `src/environments/integrated_environments`.
 

--- a/src/environments/controllers/PID.jl
+++ b/src/environments/controllers/PID.jl
@@ -1,39 +1,43 @@
 """
 Proportional-integral-derivative (PID) controller.
-Note that the derivative is obtained via low-pass-filter (LPF).
-For more details, see singular perturbation theory.
+# Notes
+The derivative term is obtained via second-order filter.
+For more details, see [1] and singular perturbation theory.
+# References
+[1] J. A. Farrell, M. Polycarpou, M. Sharma, and W. Dong, “Command Filtered Backstepping,” IEEE Transactions on Automatic Control, vol. 54, no. 6, pp. 1391–1395, Jun. 2009, doi: 10.1109/TAC.2009.2015562.
 """
 struct PID <: AbstractEnv
     K_P
     K_I
     K_D
-    τ
+    ω_n
+    ζ
     windup_limit
-    function PID(K_P, K_I, K_D; τ=1e-1, windup_limit=1e0)
+    function PID(K_P, K_I, K_D; ω_n=1e1, ζ=5e-1, windup_limit=Inf)
         @assert windup_limit > 0.0
-        new(K_P, K_I, K_D, τ, windup_limit)
+        @assert ω_n > 0.0
+        @assert ζ > 0.0
+        new(K_P, K_I, K_D, ω_n, ζ, windup_limit)
     end
 end
 
 """
-ê: the estimate of the error
 ∫e: integral of the error
+ê: the estimate of the error
+ė̂: the estimate of the error rate
 """
 function State(controller::PID)
-    function state(; ∫e=zeros(1), ê=zeros(1))
-        ComponentArray(∫e=∫e, ê=ê)
+    function state(; ∫e=zeros(1), ê=zeros(1), ė̂=zeros(1))
+        ComponentArray(∫e=∫e, ê=ê, ė̂=ė̂)
     end
 end
 
-"""
-Note: ê is estimated via LPF
-"""
 function Dynamics!(controller::PID)
-    @unpack τ, windup_limit = controller
+    @unpack ω_n, ζ, windup_limit = controller
     @Loggable function dynamics!(dx, x, p, t; e)
         @assert !(typeof(e) <: Number)  # make sure that `e` is a 1-d array
-        @unpack ∫e, ê = x
-        @onlylog e, ∫e, ê
+        @unpack ∫e, ê, ė̂ = x
+        @onlylog e, ∫e, ê, ė̂
         if norm(∫e) < windup_limit
             dx.∫e .= e
         elseif norm(∫e) > windup_limit && all(sign.(e) .* sign.(∫e) .< zero.(e))
@@ -41,18 +45,14 @@ function Dynamics!(controller::PID)
         else
             dx.∫e .= zero.(e)
         end
-        dx.ê .= deriv_ê(controller, e, ê)
+        dx.ê .= ω_n*ė̂
+        dx.ė̂ = -2*ζ*ω_n*ė̂ - ω_n*(ê - e)
     end
-end
-
-function deriv_ê(controller::PID, e, ê)
-    @unpack τ = controller
-    (e - ê) / τ
 end
 
 function Command(controller::PID)
     @unpack K_P, K_I, K_D = controller
-    function command(e, ∫e, ê)
-        -(K_P*e + K_I*∫e + K_D*deriv_ê(controller, e, ê))
+    function command(e, ∫e, ė̂)
+        -(K_P*e + K_I*∫e + K_D*ė̂)
     end
 end

--- a/test/environments/controllers/pid.jl
+++ b/test/environments/controllers/pid.jl
@@ -6,7 +6,7 @@ using Plots
 
 
 function test()
-    K_P, K_I, K_D = 1e1, 1e0, 1e0
+    K_P, K_I, K_D = 1e1, 1e2, 1e0
     controller = PID(K_P, K_I, K_D)
     x0_pid = State(controller)()
     A = ones(1, 1)
@@ -15,13 +15,15 @@ function test()
     x0 = State(linear_system)([1])
     X0 = ComponentArray(x=x0, pid=x0_pid)
     command_pid = Command(controller)
-    x_des = zeros(1)
+    x_des(t) = [t]
+    ẋ_des(t) = [1.0]
     tf = 20.0
     @Loggable function dynamics!(dX, X, p, t)
-        @unpack ∫e, ê = X.pid
+        @unpack ∫e, ė̂ = X.pid
         @unpack x = X
-        e = x - x_des
-        u = command_pid(e, ∫e, ê)
+        e = x - x_des(t)
+        u = command_pid(e, ∫e, ė̂)
+        @onlylog ė = A*x + B*u - ẋ_des(t)  # true
         @nested_log Dynamics!(linear_system)(dX.x, X.x, (), t; u=u)
         @nested_log Dynamics!(controller)(dX.pid, X.pid, (), t; e=e)
     end
@@ -34,7 +36,13 @@ function test()
     ts = df.time
     es = df.sol |> Map(datum -> datum.e) |> collect
     ês = df.sol |> Map(datum -> datum.ê) |> collect
-    p = plot(; title="error")
-    plot!(p, ts, hcat(es...)'; label="e")
-    plot!(p, ts, hcat(ês...)'; label="ê")
+    ės = df.sol |> Map(datum -> datum.ė) |> collect
+    ė̂s = df.sol |> Map(datum -> datum.ė̂) |> collect
+    p_e = plot(; title="error")
+    plot!(p_e, ts, hcat(es...)'; label="e")
+    plot!(p_e, ts, hcat(ês...)'; label="ê")
+    p_ė = plot(; title="error rate")
+    plot!(p_ė, ts, hcat(ės...)'; label="ė")
+    plot!(p_ė, ts, hcat(ė̂s...)'; label="ė̂")
+    p = plot(p_e, p_ė; layout=(2, 1))
 end


### PR DESCRIPTION
D term is now obtained via second-order fitler based on singular perturbation theory.
See [J. A. Farrell, M. Polycarpou, M. Sharma, and W. Dong, “Command Filtered Backstepping,” IEEE Transactions on Automatic Control, vol. 54, no. 6, pp. 1391–1395, Jun. 2009, doi: 10.1109/TAC.2009.2015562.](https://ieeexplore.ieee.org/abstract/document/4982643).
