### PR TITLE
Add a test for InnerLoopGeometricTrackingController

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlightSims"
 uuid = "a4c2f6ca-3fbe-4430-8ede-32935de4c069"
 authors = ["JinraeKim <kjl950403@gmail.com> and contributors"]
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 FSimBase = "731e945d-f3ed-49a1-bee2-3998705ef155"

--- a/Project.toml
+++ b/Project.toml
@@ -19,11 +19,11 @@ julia = "1"
 [extras]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [targets]
 test = ["Test", "DifferentialEquations", "LinearAlgebra", "Plots", "Transducers", "ForwardDiff", "ComponentArrays"]

--- a/test/environments/controllers/geometric_tracking_inner_outer.jl
+++ b/test/environments/controllers/geometric_tracking_inner_outer.jl
@@ -7,7 +7,7 @@ using ComponentArrays
 using LinearAlgebra
 
 
-function main(; Δt=0.05, tf=1.0)
+function outerloop(; Δt=0.05, tf=1.0)
     multicopter = LeeQuadcopter()
     (; m, g) = multicopter
     X0_multicopter = State(multicopter)()
@@ -56,6 +56,151 @@ function main(; Δt=0.05, tf=1.0)
 end
 
 
+function innerloop(; Δt=0.05, tf=1.0)
+    multicopter = LeeQuadcopter()
+    controller = InnerLoopGeometricTrackingController()
+    (; m, g, J) = multicopter
+    X0_multicopter = State(multicopter)()
+    X0_controller = State(controller)()
+    X0 = ComponentArray(
+                        multicopter=X0_multicopter,
+                        controller=X0_controller,
+                       )
+
+    p_d = t -> zeros(3)
+    v_d = t -> ForwardDiff.derivative(p_d, t)
+    a_d = t -> ForwardDiff.derivative(v_d, t)
+
+    _b_3_d = t -> m * a_d(t) + m*g*[0, 0, 1]
+    b_1_d = t -> [cos(0.1*pi*t), sin(0.1*pi*t), 0]
+    b_1_d_dot = t -> ForwardDiff.derivative(b_1_d, t)
+    b_1_d_ddot = t -> ForwardDiff.derivative(b_1_d_dot, t)
+
+    @Loggable function dynamics!(dX, X, params, t)
+        (; R, ω) = X.multicopter
+        (; z2_f, z2_f_dot) = X.controller
+        e3 = [0, 0, 1]
+        _b_3_d_dot = controller.ω_n_f * z2_f
+        _b_3_d_ddot = controller.ω_n_f_dot * z2_f_dot
+        ν = Command(
+                    controller, R', ω;
+                    b_1_d=b_1_d(t),
+                    b_1_d_dot=b_1_d_dot(t),
+                    b_1_d_ddot=b_1_d_ddot(t),
+                    _b_3_d=_b_3_d(t),
+                    _b_3_d_dot=_b_3_d_dot,
+                    _b_3_d_ddot=_b_3_d_ddot,
+                    J=J,
+                   )
+        @onlylog state = X.multicopter
+        @onlylog input = ν
+        FSimZoo.__Dynamics!(multicopter)(dX.multicopter, X.multicopter, params, t; f=ν[1], M=ν[2:4])
+        Dynamics!(controller)(dX.controller, X.controller, params, t; f=_b_3_d(t))
+    end
+
+    simulator = Simulator(X0, dynamics!, []; tf=tf)
+    df = solve(simulator; savestep=Δt)
+    ts = df.time
+    ps = hcat([datum.state.p for datum in df.sol]...)'
+    fig = plot(;
+               # layout=(2, 1)
+              )
+    plot!(fig, ts, ps;
+          subplot=1,
+          label=["p_x" "p_y" "p_z"], lc=:blue, ls=[:solid :dash :dot])
+    display(fig)
+end
+
+
+function integrated_inner_outer_loops(; Δt=0.05, tf=1.0)
+    multicopter = LeeQuadcopter()
+    (; m, g, J) = multicopter
+    ol_controller = OuterLoopGeometricTrackingController()
+    il_controller = InnerLoopGeometricTrackingController()
+
+    X0_multicopter = State(multicopter)()
+    X0_il_controller = State(il_controller)()
+    X0 = ComponentArray(
+                        multicopter=X0_multicopter,
+                        il_controller=X0_il_controller,
+                       )
+
+    p_d = t -> [0.4*sin(0.5*pi*t), 0.6*cos(0.5*pi*t), 0.4*t]
+    b_1_d = t -> [cos(0.1*pi*t), sin(0.1*pi*t), 0]
+
+    v_d = t -> ForwardDiff.derivative(p_d, t)
+    a_d = t -> ForwardDiff.derivative(v_d, t)
+    b_1_d_dot = t -> ForwardDiff.derivative(b_1_d, t)
+    b_1_d_ddot = t -> ForwardDiff.derivative(b_1_d_dot, t)
+
+    allocator = PseudoInverseAllocator(multicopter.B)
+
+    @Loggable function dynamics!(dX, X, params, t)
+        (; p, v, R, ω) = X.multicopter
+        (; z2_f, z2_f_dot) = X.il_controller
+        # outer-loop
+        _b_3_d = Command(
+                         ol_controller, p, v;
+                         p_d=p_d(t),
+                         v_d=v_d(t),
+                         a_d=a_d(t),
+                         m=m, g=g,
+                        )
+        # inner-loop
+        _b_3_d_dot = il_controller.ω_n_f * z2_f
+        _b_3_d_ddot = il_controller.ω_n_f_dot * z2_f_dot
+        ν = Command(
+                    il_controller, R', ω;
+                    b_1_d=b_1_d(t),
+                    b_1_d_dot=b_1_d_dot(t),
+                    b_1_d_ddot=b_1_d_ddot(t),
+                    _b_3_d=_b_3_d,
+                    _b_3_d_dot=_b_3_d_dot,
+                    _b_3_d_ddot=_b_3_d_ddot,
+                    J=J,
+                   )
+        # control allocation
+        u = Command(allocator)(ν)
+        @nested_log :multicopter FSimZoo._Dynamics!(multicopter)(dX.multicopter, X.multicopter, params, t; u=u)
+        @log ν
+        # @nested_log :multicopter FSimZoo.__Dynamics!(multicopter)(dX.multicopter, X.multicopter, params, t; f=ν[1], M=ν[2:4])
+        @nested_log :il_controller Dynamics!(il_controller)(dX.il_controller, X.il_controller, params, t; f=_b_3_d)
+    end
+
+    simulator = Simulator(X0, dynamics!, []; tf=tf)
+    df = solve(simulator; savestep=Δt)
+    ts = df.time
+    ps = hcat([datum.multicopter.state.p for datum in df.sol]...)'
+    u_saturateds = hcat([datum.multicopter.input.u_saturated for datum in df.sol]...)'
+    νs = [datum.ν for datum in df.sol]
+    p_refs = hcat([p_d(t) for t in ts]...)'
+    fig = plot(layout=(3, 1))
+    plot!(fig, ts, ps;
+          subplot=1,
+          label=["p_x" "p_y" "p_z"], lc=:blue, ls=[:solid :dash :dot],
+          legend=:outertopright,
+         )
+    plot!(fig, ts, p_refs;
+          subplot=1,
+          label=["r_x" "r_y" "r_z"], lc=:red, ls=[:solid :dash :dot],
+          legend=:outertopright,
+         )
+    plot!(fig, ts, u_saturateds;
+          subplot=2,
+          label=["u_1" "u_2" "u_3" "u_4"], lc=:blue, ls=[:solid :dash :dot :dashdot],
+          legend=:outertopright,
+         )
+    plot!(fig, ts, hcat([[1e-2, 1, 1, 1] .* ν for ν in νs]...)';
+          subplot=3,
+          label=["0.01 * f" "M_x" "M_y" "M_z"], lc=:blue, ls=[:solid :dash :dot :dashdot],
+          legend=:outertopright,
+         )
+    display(fig)
+end
+
+
 @testset "geometric tracking inner outer" begin
-    main()
+    outerloop()
+    innerloop()
+    # integrated_inner_outer_loops()  # TODO
 end


### PR DESCRIPTION
After https://github.com/JinraeKim/FSimZoo.jl/pull/18 is merged and a new version of `FSimZoo.jl` is bumped.

# Summary

## Results
<img width="833" alt="image" src="https://user-images.githubusercontent.com/43136096/235302775-29d83bf2-11fc-4b08-9264-22c6571d5d49.png">

## Notes
As each controller for inner- and outer-loops are integrated, this is quite sensitive to the controller parameter tuning (compared to the `GeometricTrackingController`, which deals with the position tracking at once #153 ).

It is probably because the inner-loop controller estimates time derivatives of desired forces for this hierarchical structure.